### PR TITLE
Fix audioContext check for Safari

### DIFF
--- a/src/utils/errorHandler.js
+++ b/src/utils/errorHandler.js
@@ -123,9 +123,11 @@ export const logError = (errorType, error, context = {}) => {
  * @returns {Object} Object with support status and missing features
  */
 export const checkBrowserSupport = () => {
+  const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+
   const features = {
     webGPU: !!navigator.gpu,
-    audioContext: !!window.AudioContext,
+    audioContext: !!AudioContextClass,
     mediaDevices: !!navigator.mediaDevices,
     getUserMedia: !!(navigator.mediaDevices && navigator.mediaDevices.getUserMedia),
     webWorkers: !!window.Worker,


### PR DESCRIPTION
## Summary
- improve browser detection logic in `checkBrowserSupport`

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint src/utils/errorHandler.js` *(fails to find plugin)*