### PR TITLE
Add persistent dark mode toggle

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import { TranscriptionHistory } from "./components/TranscriptionHistory";
 import { FileUpload } from "./components/FileUpload";
 import { ErrorMessage } from "./components/ErrorMessage";
 import { ModelSelector } from "./components/ModelSelector";
+import { Header } from "./components/Header";
 import { 
   saveLanguagePreference, 
   loadLanguagePreference,
@@ -19,7 +20,9 @@ import {
   saveTranscriptionHistory,
   loadTranscriptionHistory,
   saveModelPreference,
-  loadModelPreference
+  loadModelPreference,
+  saveDarkModePreference,
+  loadDarkModePreference
 } from "./utils/storage";
 import {
   ERROR_TYPES,
@@ -64,6 +67,9 @@ function App() {
   // Auto-processing
   const [autoProcess, setAutoProcess] = useState(() => loadAutoProcessPreference());
   const processingTimeoutRef = useRef(null);
+
+  // Theme
+  const [darkMode, setDarkMode] = useState(() => loadDarkModePreference());
   
   // UI state
   const [activeTab, setActiveTab] = useState("microphone"); // "microphone" or "file"
@@ -109,6 +115,11 @@ function App() {
   useEffect(() => {
     saveModelPreference(currentModel);
   }, [currentModel]);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', darkMode);
+    saveDarkModePreference(darkMode);
+  }, [darkMode]);
 
   // We use the `useEffect` hook to setup the worker as soon as the `App` component is mounted.
   useEffect(() => {
@@ -571,10 +582,15 @@ function App() {
     }
   };
 
+  const toggleDarkMode = () => {
+    setDarkMode((prev) => !prev);
+  };
+
   return (
     <ErrorBoundary>
       <BrowserCheck />
       <div className="flex flex-col h-screen h-screen-dynamic mx-auto justify-end text-gray-800 dark:text-gray-200 bg-white dark:bg-gray-900">
+        <Header darkMode={darkMode} toggleDarkMode={toggleDarkMode} />
         {
           <div className="h-full overflow-auto scrollbar-thin flex justify-center items-center flex-col relative">
             <div className="flex flex-col items-center mb-1 max-w-[400px] text-center px-4 sm:px-0">

--- a/src/components/AudioVisualizer.jsx
+++ b/src/components/AudioVisualizer.jsx
@@ -35,7 +35,7 @@ export function AudioVisualizer({ stream, ...props }) {
       analyser.getByteTimeDomainData(dataArray);
 
       // Use theme-aware colors
-      const isDarkMode = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const isDarkMode = document.documentElement.classList.contains('dark');
       
       canvasCtx.fillStyle = isDarkMode ? "rgb(31, 41, 55)" : "rgb(255, 255, 255)";
       canvasCtx.fillRect(0, 0, canvas.width, canvas.height);

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -7,6 +7,7 @@ const STORAGE_KEYS = {
   AUTO_PROCESS: 'whisper-webgpu-auto-process',
   TRANSCRIPTION_HISTORY: 'whisper-webgpu-history',
   MODEL_PREFERENCE: 'whisper-webgpu-model',
+  THEME: 'whisper-webgpu-theme',
 };
 
 /**
@@ -108,6 +109,25 @@ export const saveModelPreference = (model) => {
  */
 export const loadModelPreference = () => {
   return loadFromStorage(STORAGE_KEYS.MODEL_PREFERENCE, 'base');
+};
+
+/**
+ * Save dark mode preference
+ * @param {boolean} darkMode - Whether dark mode is enabled
+ */
+export const saveDarkModePreference = (darkMode) => {
+  return saveToStorage(STORAGE_KEYS.THEME, darkMode);
+};
+
+/**
+ * Load dark mode preference
+ * Defaults to system preference when not set
+ * @returns {boolean} Dark mode setting
+ */
+export const loadDarkModePreference = () => {
+  const systemPrefersDark =
+    window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+  return loadFromStorage(STORAGE_KEYS.THEME, systemPrefersDark);
 };
 
 /**

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- add a theme entry in storage utilities
- persist dark mode preference and expose helpers
- wire up a dark mode toggle with a header component
- apply dark mode class to `document.documentElement`
- update `AudioVisualizer` to read theme class
- switch Tailwind to class-based dark mode

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*