### PR TITLE
Fix audio chunk reprocessing bug

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -361,9 +361,13 @@ function App() {
 
   const processAudioChunks = async () => {
     if (chunks.length === 0) return;
-    
+
+    // Copy and clear chunks to avoid reprocessing previously collected audio
+    const chunksToProcess = [...chunks];
+    setChunks([]);
+
     // Generate from data
-    const blob = new Blob(chunks, { type: recorderRef.current.mimeType });
+    const blob = new Blob(chunksToProcess, { type: recorderRef.current.mimeType });
 
     const fileReader = new FileReader();
 


### PR DESCRIPTION
## Summary
- clear processed audio chunks in `processAudioChunks` to avoid reprocessing previously collected data

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*